### PR TITLE
support TrySubmit

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -26,6 +26,8 @@ type Broadcaster interface {
 	Close() error
 	// Submit a new object to all subscribers
 	Submit(interface{})
+	// Try Submit a new object to all subscribers return false if input chan is fill
+	TrySubmit(interface{}) bool
 }
 
 func (b *broadcaster) broadcast(m interface{}) {
@@ -83,4 +85,16 @@ func (b *broadcaster) Submit(m interface{}) {
 	if b != nil {
 		b.input <- m
 	}
+}
+
+func (b *broadcaster) TrySubmit(m interface{}) bool {
+	if b != nil {
+		select {
+		case b.input <- m:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -31,6 +31,28 @@ func TestBroadcast(t *testing.T) {
 	wg.Wait()
 }
 
+func TestBroadcastTrySubmit(t *testing.T) {
+	b := NewBroadcaster(1)
+	defer b.Close()
+
+	if ok := b.TrySubmit(0); !ok {
+		t.Fatalf("1st TrySubmit assert error expect=true actual=%v", ok)
+	}
+
+	if ok := b.TrySubmit(1); ok {
+		t.Fatalf("2nd TrySubmit assert error expect=false actual=%v", ok)
+	}
+
+	cch := make(chan interface{})
+	b.Register(cch)
+	defer b.Unregister(cch)
+	<-cch
+
+	if ok := b.TrySubmit(1); !ok {
+		t.Fatalf("3rd TrySubmit assert error expect=true actual=%v", ok)
+	}
+}
+
 func TestBroadcastCleanup(t *testing.T) {
 	b := NewBroadcaster(100)
 	b.Register(make(chan interface{}))


### PR DESCRIPTION
The goroutine that calls broadcaster.Submit will be blocked if broadcaster.input is full, so TrySubmit is added for caller goroutine to choose either try for later or drop this message.