### PR TITLE
fix: fix broadcast msg chan block issue

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -3,7 +3,6 @@ Package broadcast provides pubsub of messages over channels.
 
 A provider has a Broadcaster into which it Submits messages and into
 which subscribers Register to pick up those messages.
-
 */
 package broadcast
 
@@ -32,7 +31,12 @@ type Broadcaster interface {
 
 func (b *broadcaster) broadcast(m interface{}) {
 	for ch := range b.outputs {
-		ch <- m
+		// if exist one output consume the chan message is too slow,
+		// will block other output receive the msg.
+		select {
+		case ch <- m:
+		default:
+		}
 	}
 }
 

--- a/mux_observer.go
+++ b/mux_observer.go
@@ -48,7 +48,12 @@ func (m *MuxObserver) Close() error {
 
 func (m *MuxObserver) broadcast(to taggedObservation) {
 	for ch := range m.subs[to.sub] {
-		ch <- to.ob
+		// if exist one output consume the chan message is too slow,
+		// will block other output receive the msg.
+		select {
+		case ch <- to.ob:
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
if outputs chan exist one consumer msg too slow, will cause the msg broadcast block by this chan, then cause other chan can not consumer msg normal. so add select default condition to skip msg to send if the chan is blocked.